### PR TITLE
[Sikkerhet] Oppdaterer catalog-info.yaml med komponent

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 organization: Eiendom
 product: Grunnbok
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,39 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "etinglysing-vedlegg"
+  tags:
+  - "public"
+spec:
+  type: "documentation"
+  lifecycle: "production"
+  owner: "digibok"
+  system: "grunnbok"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_etinglysing-vedlegg"
+  title: "Security Champion etinglysing-vedlegg"
+spec:
+  type: "security_champion"
+  parent: "eiendom_security_champions"
+  members:
+  - "haakl"
+  children:
+  - "resource:etinglysing-vedlegg"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "etinglysing-vedlegg"
+  links:
+  - url: "https://github.com/kartverket/etinglysing-vedlegg"
+    title: "etinglysing-vedlegg på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_etinglysing-vedlegg"
+  system: "grunnbok"
+  dependencyOf:
+  - "component:etinglysing-vedlegg"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.