### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 # Denne koden forvaltes av:  Team DigiBok
 
 * @kartverket/digibok
-/.sikkerhet/ @haakl
+/.security/ @haakl

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Eiendom
 product: Grunnbok
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "digibok"
   system: "grunnbok"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_etinglysing-vedlegg"
-  title: "Security Champion etinglysing-vedlegg"
-spec:
-  type: "security_champion"
-  parent: "eiendom_security_champions"
-  members:
-  - "haakl"
-  children:
-  - "resource:etinglysing-vedlegg"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "etinglysing-vedlegg"
-  links:
-  - url: "https://github.com/kartverket/etinglysing-vedlegg"
-    title: "etinglysing-vedlegg på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_etinglysing-vedlegg"
-  dependencyOf:
-  - "component:etinglysing-vedlegg"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml